### PR TITLE
Exclude heritage from open issues query

### DIFF
--- a/src/service/persistence.js
+++ b/src/service/persistence.js
@@ -47,7 +47,7 @@ async function startHelpRequest(jiraId) {
 }
 
 async function searchForUnassignedOpenIssues() {
-    const jqlQuery = `project = ${jiraProject} AND type = "${issueTypeName}" AND status = Open and assignee is EMPTY ORDER BY created ASC`;
+    const jqlQuery = `project = ${jiraProject} AND type = "${issueTypeName}" AND status = Open and assignee is EMPTY AND labels not in ("Heritage") ORDER BY created ASC`;
     try {
         return await jira.searchJira(
             jqlQuery,


### PR DESCRIPTION
The main BAU team isn't going to be working on heritage tickets for now, if/when that changes this can be reverted