### PR TITLE
Add healthcheck on connection

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,7 +47,13 @@ const server = http.createServer((req, res) => {
     } else if (req.url === '/health') {
         res.end(`<h1>slack-help-bot</h1>`)
     } else if (req.url === '/health/liveness') {
-        res.end(`<h1>slack-help-bot</h1>`)
+        if (app.receiver.client.badConnection) {
+            res.statusCode = 500
+            res.end('Internal Server Error');
+            return;
+        }
+
+        res.end('OK');
     } else if (req.url === '/health/readiness') {
         res.end(`<h1>slack-help-bot</h1>`)
     } else {


### PR DESCRIPTION
Fixes https://github.com/hmcts/slack-help-bot/issues/45

Workaround from https://github.com/slackapi/node-slack-sdk/issues/1243#issuecomment-860937370

I've validated that turning off my Wi-Fi can simulate this to at least get the health probe to fail (doesn't hit the same issue but others say this has worked around it for them)