### PR TITLE
Fix failed requests to jira api not being caught

### DIFF
--- a/app.js
+++ b/app.js
@@ -236,12 +236,7 @@ const ws = new WorkflowStep('superbot_help_request', {
                 `area-${inputs.area.value.toLowerCase().replace(' ', '-')}`,
                 `team-${inputs.team.value.toLowerCase().replace(' ', '-')}`
             ]
-        })
-
-        if (!jiraId) {
-            console.log("Posting help request to Jira Failed.");
-            fail();
-        }
+        });
 
         const result = await client.chat.postMessage({
             channel: reportChannel,

--- a/src/service/persistence.js
+++ b/src/service/persistence.js
@@ -180,7 +180,7 @@ async function createHelpRequest({
         // in case the user doesn't exist in Jira use the system user
         result = await createHelpRequestInJira(summary, project, systemUser, labels);
 
-        if (!result.key) {
+        if (result && !result.key) {
             console.log("Error creating help request in jira", JSON.stringify(result));
         }
     }

--- a/src/service/persistence.js
+++ b/src/service/persistence.js
@@ -174,14 +174,14 @@ async function createHelpRequest({
 
     // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-post
     // note: fields don't match 100%, our Jira version is a bit old (still a supported LTS though)
-    let result = await createHelpRequestInJira(summary, project, user, labels);
+    const result = await createHelpRequestInJira(summary, project, user, labels);
 
     if (!result.key) {
         // in case the user doesn't exist in Jira use the system user
         result = await createHelpRequestInJira(summary, project, systemUser, labels);
 
         if (!result.key) {
-            console.log("Error creating help request in jira", JSON.stringify(n_err));
+            console.log("Error creating help request in jira", JSON.stringify(result));
         }
     }
 

--- a/src/service/persistence.js
+++ b/src/service/persistence.js
@@ -170,26 +170,19 @@ async function createHelpRequest({
                                  }) {
     const user = convertEmail(userEmail)
 
-    const project = await jira.getProject(jiraProject)
+    const project = await jira.getProject(jiraProject);
 
     // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-post
     // note: fields don't match 100%, our Jira version is a bit old (still a supported LTS though)
-    let result
-    try {
-        result = await createHelpRequestInJira(summary, project, user, labels);
-    } catch (err) {
-        try {
-            // in case the user doesn't exist in Jira use the system user
-            result = await createHelpRequestInJira(summary, project, systemUser, labels);
-        } catch (n_err) {
-            // error we don't know about, should probably log.
+    let result = await createHelpRequestInJira(summary, project, user, labels);
+
+    if (!result.key) {
+        // in case the user doesn't exist in Jira use the system user
+        result = await createHelpRequestInJira(summary, project, systemUser, labels);
+
+        if (!result.key) {
             console.log("Error creating help request in jira", JSON.stringify(n_err));
         }
-    }
-
-    if (!result.key)
-    {
-        console.log("Failed to create help request in jira", JSON.stringify(result));
     }
 
     return result.key

--- a/src/service/persistence.js
+++ b/src/service/persistence.js
@@ -178,13 +178,18 @@ async function createHelpRequest({
     try {
         result = await createHelpRequestInJira(summary, project, user, labels);
     } catch (err) {
-        try {   
+        try {
             // in case the user doesn't exist in Jira use the system user
             result = await createHelpRequestInJira(summary, project, systemUser, labels);
         } catch (n_err) {
             // error we don't know about, should probably log.
             console.log("Error creating help request in jira", JSON.stringify(n_err));
         }
+    }
+
+    if (!result.key)
+    {
+        console.log("Failed to create help request in jira", JSON.stringify(result));
     }
 
     return result.key


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###

jira-client made a breaking change in-between updates where failed requests to the API would no longer throw an exception. This prevented a catch statement from triggering when a user who did not exist in jira attempted to report a help request. This PR replaces the catch statement with an error check that should restore the original behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
