### PR TITLE
Fallback to system user if creation fails

### DIFF
--- a/src/service/persistence.js
+++ b/src/service/persistence.js
@@ -176,9 +176,11 @@ async function createHelpRequest({
 
     // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-post
     // note: fields don't match 100%, our Jira version is a bit old (still a supported LTS though)
-    let result = await createHelpRequestInJira(summary, project, user, labels);
 
-    if (!result.key) {
+    let result
+    try {
+        result = await createHelpRequestInJira(summary, project, user, labels);
+    } catch(err) {
         // in case the user doesn't exist in Jira use the system user
         result = await createHelpRequestInJira(summary, project, systemUser, labels);
 


### PR DESCRIPTION
I guess before it returned an empty result but behaviour changed to be an error at some point