### PR TITLE
Migrate PlatOps help bot entry point from workflow to shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .tokens.json
+.DS_Store

--- a/app.js
+++ b/app.js
@@ -140,32 +140,35 @@ function checkSlackResponseError(res, message) {
 })();
 
 // New main entry point for the application
-app.shortcut("begin_help_request_sc", async({body, context, client, ack}) => {
-  await ack();
+app.shortcut(
+  "begin_help_request_sc",
+  async ({ body, context, client, ack }) => {
+    await ack();
 
-  const userId = context.userId;
+    const userId = context.userId;
 
-  const openDmResponse = await client.conversations.open({
-    users: userId,
-    return_im: true,
-  });
+    const openDmResponse = await client.conversations.open({
+      users: userId,
+      return_im: true,
+    });
 
-  const channelId = openDmResponse.channel.id;
+    const channelId = openDmResponse.channel.id;
 
-  const postMessageResponse = await client.chat.postMessage({
-    channel: channelId,
-    text: "Hello!",
-    blocks: helpFormGreetingBlocks({
-      user: userId,
-      isAdvanced: false,
-    }),
-  });
+    const postMessageResponse = await client.chat.postMessage({
+      channel: channelId,
+      text: "Hello!",
+      blocks: helpFormGreetingBlocks({
+        user: userId,
+        isAdvanced: false,
+      }),
+    });
 
-  checkSlackResponseError(
-    postMessageResponse,
-    "An error occurred when posting a direct message",
-  );
-})
+    checkSlackResponseError(
+      postMessageResponse,
+      "An error occurred when posting a direct message",
+    );
+  },
+);
 
 app.action(
   "show_plato_dialogue",


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17080

### Change description ###

slack-help-bot is currently being invoked using deprecated workflow functionality which will be turned off in September: https://api.slack.com/changelog/2023-08-workflow-steps-from-apps-step-back

 This PR changes to a shortcut-based invocation.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
