### PR TITLE
Added DM entrypoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,14 +139,8 @@ function checkSlackResponseError(res, message) {
   console.log("⚡️ Bolt app started");
 })();
 
-// New main entry point for the application
-app.shortcut(
-  "begin_help_request_sc",
-  async ({ body, context, client, ack }) => {
-    await ack();
-
-    const userId = context.userId;
-
+async function begin_help_request(userId, client) {
+  try {
     const openDmResponse = await client.conversations.open({
       users: userId,
       return_im: true,
@@ -167,6 +161,17 @@ app.shortcut(
       postMessageResponse,
       "An error occurred when posting a direct message",
     );
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+// New main entry point for the application
+app.shortcut(
+  "begin_help_request_sc",
+  async ({ body, context, client, ack }) => {
+    await ack();
+    await begin_help_request(context.userId, client);
   },
 );
 
@@ -461,6 +466,7 @@ app.action(
 // need app_mentions:read and chat:write scopes
 app.event("app_mention", async ({ event, context, client, say }) => {
   try {
+
     // filter unwanted channels in case someone invites the bot to it
     // and only look at threaded messages
     if (event.channel === reportChannelId && event.thread_ts) {
@@ -765,69 +771,90 @@ function convertProfileToName(profile) {
   return name;
 }
 
+// Processes whenever the bot receives a message
 app.event("message", async ({ event, context, client, say }) => {
   try {
+
+    // Filters for direct(instant) messages
+    if (event.channel_type === "im") {
+      switch (event.text.toLowerCase()) {
+        case "help":
+          // Open the PlatOps help request form. Alternative to the shortcut above
+          await begin_help_request(context.userId, client);
+          return;
+        default:
+          // 
+          await say("Sorry, I didn't catch that. Here's what I can help you with:\n`help` Open a Platform Help Request");
+          return;
+      }
+    }
+
     // filter unwanted channels in case someone invites the bot to it
     // and only look at threaded messages
-    if (event.channel === reportChannelId && event.thread_ts) {
-      const slackLink = (
-        await client.chat.getPermalink({
-          channel: event.channel,
-          message_ts: event.thread_ts,
-        })
-      ).permalink;
+    if (event.channel != reportChannelId) return;
+    if (!event.thread_ts) return;
 
-      const user = await client.users.profile.get({
-        user: event.user,
+    // The code below here monitors the thread of any help request and
+    // automatically mirrors the messages to the Jira ticket.
+
+    const slackLink = (
+      await client.chat.getPermalink({
+        channel: event.channel,
+        message_ts: event.thread_ts,
+      })
+    ).permalink;
+
+    const user = await client.users.profile.get({
+      user: event.user,
+    });
+
+    const name = convertProfileToName(user.profile);
+
+    // Should be able to get root message using timestamp
+    const helpRequestMessages = (
+      await client.conversations.replies({
+        channel: reportChannelId,
+        ts: event.thread_ts,
+        limit: 200, // after a thread is 200 long we'll break but good enough for now
+      })
+    ).messages;
+
+    if (
+      helpRequestMessages.length > 0 &&
+      (helpRequestMessages[0].text === "New platform help request raised" ||
+        helpRequestMessages[0].text === "Duplicate issue")
+    ) {
+      const jiraId = extractJiraIdFromBlocks(helpRequestMessages[0].blocks);
+
+      const groupRegex = /<!subteam\^.+\|([^>.]+)>/g;
+      const usernameRegex = /<@([^>.]+)>/g;
+
+      let possibleNewTargetText = event.text.replace(
+        groupRegex,
+        (match, $1) => $1,
+      );
+
+      const newTargetText = await replaceAsync(
+        possibleNewTargetText,
+        usernameRegex,
+        async (match, $1) => {
+          const user = await client.users.profile.get({
+            user: $1,
+          });
+          return `@${convertProfileToName(user.profile)}`;
+        },
+      );
+
+      await addCommentToHelpRequest(jiraId, {
+        slackLink,
+        name,
+        message: newTargetText,
       });
-
-      const name = convertProfileToName(user.profile);
-
-      const helpRequestMessages = (
-        await client.conversations.replies({
-          channel: reportChannelId,
-          ts: event.thread_ts,
-          limit: 200, // after a thread is 200 long we'll break but good enough for now
-        })
-      ).messages;
-
-      if (
-        helpRequestMessages.length > 0 &&
-        (helpRequestMessages[0].text === "New platform help request raised" ||
-          helpRequestMessages[0].text === "Duplicate issue")
-      ) {
-        const jiraId = extractJiraIdFromBlocks(helpRequestMessages[0].blocks);
-
-        const groupRegex = /<!subteam\^.+\|([^>.]+)>/g;
-        const usernameRegex = /<@([^>.]+)>/g;
-
-        let possibleNewTargetText = event.text.replace(
-          groupRegex,
-          (match, $1) => $1,
-        );
-
-        const newTargetText = await replaceAsync(
-          possibleNewTargetText,
-          usernameRegex,
-          async (match, $1) => {
-            const user = await client.users.profile.get({
-              user: $1,
-            });
-            return `@${convertProfileToName(user.profile)}`;
-          },
-        );
-
-        await addCommentToHelpRequest(jiraId, {
-          slackLink,
-          name,
-          message: newTargetText,
-        });
-      } else {
-        // either need to implement pagination or find a better way to get the first message in the thread
-        console.warn(
-          "Could not find jira ID, possibly thread is longer than 200 messages, TODO implement pagination",
-        );
-      }
+    } else {
+      // either need to implement pagination or find a better way to get the first message in the thread
+      console.warn(
+        "Could not find jira ID, possibly thread is longer than 200 messages, TODO implement pagination",
+      );
     }
   } catch (error) {
     console.error(error);
@@ -998,10 +1025,10 @@ app.action(
           result.fields.assignee === null
             ? null
             : (
-                await client.users.lookupByEmail({
-                  email: result.fields.assignee.emailAddress,
-                })
-              ).user.enterprise_user.id;
+              await client.users.lookupByEmail({
+                email: result.fields.assignee.emailAddress,
+              })
+            ).user.enterprise_user.id;
 
         return appHomeIssueBlocks({
           summary: result.fields.summary,

--- a/app.js
+++ b/app.js
@@ -162,7 +162,7 @@ async function begin_help_request(userId, client) {
       "An error occurred when posting a direct message",
     );
   } catch (error) {
-    console.error(error)
+    console.error(error);
   }
 }
 
@@ -466,7 +466,6 @@ app.action(
 // need app_mentions:read and chat:write scopes
 app.event("app_mention", async ({ event, context, client, say }) => {
   try {
-
     // filter unwanted channels in case someone invites the bot to it
     // and only look at threaded messages
     if (event.channel === reportChannelId && event.thread_ts) {
@@ -774,7 +773,6 @@ function convertProfileToName(profile) {
 // Processes whenever the bot receives a message
 app.event("message", async ({ event, context, client, say }) => {
   try {
-
     // Filters for direct(instant) messages
     if (event.channel_type === "im") {
       switch (event.text.toLowerCase()) {
@@ -783,8 +781,10 @@ app.event("message", async ({ event, context, client, say }) => {
           await begin_help_request(context.userId, client);
           return;
         default:
-          // 
-          await say("Sorry, I didn't catch that. Here's what I can help you with:\n`help` Open a Platform Help Request");
+          //
+          await say(
+            "Sorry, I didn't catch that. Here's what I can help you with:\n`help` Open a Platform Help Request",
+          );
           return;
       }
     }
@@ -1025,10 +1025,10 @@ app.action(
           result.fields.assignee === null
             ? null
             : (
-              await client.users.lookupByEmail({
-                email: result.fields.assignee.emailAddress,
-              })
-            ).user.enterprise_user.id;
+                await client.users.lookupByEmail({
+                  email: result.fields.assignee.emailAddress,
+                })
+              ).user.enterprise_user.id;
 
         return appHomeIssueBlocks({
           summary: result.fields.summary,


### PR DESCRIPTION
### Jira link (if applicable)

[DTSPO-17375](https://tools.hmcts.net/jira/browse/DTSPO-17375)

### Change description ###

An unforeseen consequence of [DTSPO-17080](https://tools.hmcts.net/jira/browse/DTSPO-17080), users outside of the 'HMCTS Reform' Workspace in Slack to which the bot is distributed are unable to see the new shortcut entrypoint for raising the help request form.

This resulted in [DTSPO-17374](https://tools.hmcts.net/jira/browse/DTSPO-17374) in which a user was unable to raise a help request. This case can be remedied by simply adding the user to the workspace, however with multiple concurrent slack workspaces under justice UK, it may be advisable to allow users to invoke the workflow by sending a direct message to the bot.

This should enable anyone with access to #platops-help to invoke the shortcut simply by messaging the bot user and require hopping between fewer channels to do so.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
