### PR TITLE
Fixups for AI PoC

### DIFF
--- a/components/infrastructure/app-insights.tf
+++ b/components/infrastructure/app-insights.tf
@@ -8,3 +8,9 @@ module "application_insights" {
 
   common_tags = local.common_tags
 }
+
+resource "azurerm_key_vault_secret" "app_insights_connection_string" {
+  name         = "app-insights-connection-string"
+  key_vault_id = data.azurerm_key_vault.mgmt_kv.id
+  value        = module.application_insights.connection_string
+}

--- a/src/messages/helpFormMain.js
+++ b/src/messages/helpFormMain.js
@@ -175,6 +175,10 @@ function relatedIssueBlock(issue) {
 }
 
 function helpFormRelatedIssuesBlocks({ relatedIssues }) {
+  if (relatedIssues.length === 0) {
+    return [];
+  }
+
   const header = [
     {
       type: "divider",

--- a/src/modules/appInsights.js
+++ b/src/modules/appInsights.js
@@ -2,9 +2,9 @@ const appInsights = require("applicationinsights");
 const config = require("config");
 
 const enableAppInsights = () => {
-  if (config.has("app_insights.instrumentation_key")) {
+  if (config.has("app_insights.app-insights-connection-string")) {
     appInsights
-      .setup(config.get("app_insights.instrumentation_key"))
+      .setup(config.get("app_insights.app-insights-connection-string"))
       .setAutoCollectConsole(true, true);
     appInsights.defaultClient.context.tags[
       appInsights.defaultClient.context.keys.cloudRole

--- a/src/slackHandlers/utils/lookupUser.js
+++ b/src/slackHandlers/utils/lookupUser.js
@@ -12,6 +12,7 @@ async function lookupUser({ client, user }) {
         user,
       });
     },
+    user,
     {
       cachePolicy: "max-age",
       maxAge: 86400,


### PR DESCRIPTION
1. User cache was always the first person cached as I'd missed adding a cache key
2. If no related issues don't show that section
3. App insights was erroring, probably new version doesn't support instrumentation key (and I think that instance doesn't exist anymore either so using the new one with a connection string)