### PR TITLE
Optimise searching help requests to prefer recent ones

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -17,9 +17,13 @@ jira:
 app_insights:
   connection_string: APP_INSIGHTS_INSTRUMENTATION_KEY
 
+cosmos:
+  endpoint: COSMOS_ENDPOINT
+
 openai:
+  endpoint: AZURE_OPENAI_ENDPOINT
   deployment_name: AZURE_OPENAI_DEPLOYMENT_NAME
 
 search:
   endpoint: AZURE_SEARCH_ENDPOINT
-  index_name: AZURE_SEARCH_INDEX_NAME
+  help_requests_index_name: AZURE_SEARCH_HELP_REQUESTS_INDEX_NAME

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -30,4 +30,4 @@ openai:
 
 search:
   endpoint: "https://platops-slack-help-bot-ptl.search.windows.net"
-  index_name: "help-requests"
+  help_requests_index_name: "help-requests"

--- a/src/slackHandlers/submitInitialHelpRequest.js
+++ b/src/slackHandlers/submitInitialHelpRequest.js
@@ -5,7 +5,7 @@ const {
   helpFormRelatedIssuesBlocks,
 } = require("../messages/helpFormMain");
 const { checkSlackResponseError } = require("./errorHandling");
-const { searchDocuments } = require("../service/search");
+const { searchHelpRequests } = require("../service/searchHelpRequests");
 
 function validateInitialRequest(helpRequest) {
   let errorMessage = null;
@@ -121,7 +121,7 @@ async function submitInitialHelpRequest(body, client) {
       let relatedIssues = [];
       let aiRecommendation = {};
       try {
-        const relatedIssuesPromise = searchDocuments(
+        const relatedIssuesPromise = searchHelpRequests(
           `${helpRequest.summary} ${helpRequest.description} ${helpRequest.analysis}`,
         );
 


### PR DESCRIPTION
### Change description ###
~Prefers 1 week first, if not enough results looks at 1 month, then all time~ - Sorting by created_at seems to do the same thing with a lot less code and is simpler, could maybe take high relevance ones first if needed but lets see how this goes

Fixes https://github.com/hmcts/slack-help-bot/issues/378

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
