### PR TITLE
Add block_id to follow-up questions header and update related issues …

### DIFF
--- a/src/messages/helpFormMain.js
+++ b/src/messages/helpFormMain.js
@@ -137,6 +137,7 @@ function helpFormFollowUpBlocks({ questions, answers, isAdvanced, area }) {
   const header = [
     {
       type: "context",
+      block_id: "follow_up_questions_header",
       elements: [
         {
           type: "mrkdwn",

--- a/src/slackHandlers/submitHelpRequest.js
+++ b/src/slackHandlers/submitHelpRequest.js
@@ -105,7 +105,10 @@ function getRelatedIssuesBlocks(body) {
   const tempRelatedIssuesBlock = body.message.blocks
     .filter(
       (block) =>
-        block.type !== "input" && block.type !== "header" && !block?.accessory,
+        block.type !== "input" &&
+        block.type !== "header" &&
+        !block?.accessory &&
+        block.block_id !== "follow_up_questions_header",
     )
     .slice(2);
   return tempRelatedIssuesBlock.slice(0, tempRelatedIssuesBlock.length - 1);
@@ -145,7 +148,11 @@ async function submitHelpRequest(body, client, area) {
     // not update that field before submitting and the field may still
     // have a value in the initial_option block we set.
 
-    const inputBlocks = blocks.filter((block) => block.type === "input");
+    const inputBlocks = blocks.filter(
+      (block) =>
+        block.type === "input" &&
+        !block.block_id?.startsWith("ai_follow_up_"),
+    );
 
     const helpRequest = {
       user,
@@ -214,7 +221,7 @@ async function submitHelpRequest(body, client, area) {
         ts: body.message.ts,
         text: "Raise a help request With Platform Operations",
         errorMessage: errorMessage,
-        blocks,
+        blocks: blocks.slice(0, 50),
       });
 
       checkSlackResponseError(
@@ -257,7 +264,7 @@ async function submitHelpRequest(body, client, area) {
         channel: body.channel.id,
         ts: body.message.ts,
         text: "Raise a help request with Platform Operations",
-        blocks,
+        blocks: blocks.slice(0, 50),
       });
 
       checkSlackResponseError(

--- a/src/slackHandlers/submitHelpRequest.js
+++ b/src/slackHandlers/submitHelpRequest.js
@@ -150,8 +150,7 @@ async function submitHelpRequest(body, client, area) {
 
     const inputBlocks = blocks.filter(
       (block) =>
-        block.type === "input" &&
-        !block.block_id?.startsWith("ai_follow_up_"),
+        block.type === "input" && !block.block_id?.startsWith("ai_follow_up_"),
     );
 
     const helpRequest = {


### PR DESCRIPTION
# PR Summary

This PR fixes a ticket-submission regression introduced after AI follow-up questions were added in #717.

## Bug
Users could get stuck in a validation loop when creating a help request, repeatedly seeing:

- "Please specify what environment the issue is occurring in."

## Root cause
In [src/slackHandlers/submitHelpRequest.js](src/slackHandlers/submitHelpRequest.js), fallback values are read from `inputBlocks` using fixed indices:

- `inputBlocks[4]` → environment
- `inputBlocks[5]` → team
- `inputBlocks[6]` → area

PR #717 introduced follow-up question fields that are also `input` blocks (`block_id` starting `ai_follow_up_`).
Those extra inputs shifted the array order, so environment/team/area were read from the wrong blocks and resolved as missing.

## Fix
Update `inputBlocks` filtering to exclude AI follow-up inputs:

- keep blocks where `type === "input"`
- exclude blocks where `block_id` starts with `ai_follow_up_`

This restores correct index mapping for the main form fields and resolves the repeated validation failure.