### PR TITLE
Set sampling percentage to 100 on the Application Insights TF module

### DIFF
--- a/components/infrastructure/app-insights.tf
+++ b/components/infrastructure/app-insights.tf
@@ -3,6 +3,7 @@ module "application_insights" {
 
   product = var.product
   env     = var.env
+  sampling_percentage = 100
 
   resource_group_name = azurerm_resource_group.this.name
 


### PR DESCRIPTION
…because it does not detect "PTL" env as prod by default

### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32341

### Change description

Custom events do not get appear in Application Insights, only performance metrics etc.
After bit of investigation with a local version of the app I noticed I could get some custom metrics to appear if I recorded a large number in a loop.
Sampling within the app is set to 100% but it looks like recent-ish changes to defaults in the App Insights module have set the sampling to 1%.
So most likely what is happening is that 99% of custom events just get silenty dropped by Application Insights.
The reason for this is that the prod default logic configured in the module does not have "PTL" in the map so it considers it "non-prod", hence 1% sampling.

I am increasing sampling here to 100% explicitly to prove that this is the culprit.

### Testing done

Bunch of debugging the app locally, also can see in AZ Portal that slack-help-bot-ptl Application Insights has 1% sampling set.

### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
