### PR TITLE
Downgrade to latest available model on standard deployment

### DIFF
--- a/components/infrastructure/ai-model.tf
+++ b/components/infrastructure/ai-model.tf
@@ -1,11 +1,11 @@
 resource "azurerm_cognitive_deployment" "model" {
-  name                 = "gpt-4"
+  name                 = "gpt-5"
   cognitive_account_id = azurerm_ai_services.AIServices.id
   // region availability https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#gpt-4-and-gpt-4-turbo-model-availability
   model {
     format  = "OpenAI"
-    name    = "gpt-5.5"
-    version = "2026-04-24"
+    name    = "gpt-5.1"
+    version = "2025-11-13"
   }
 
   sku {


### PR DESCRIPTION

### Change description

apparently 5.5 is available only global standard deployment, I am not sure if we want to do it.


### Testing done

https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure-region-availability?tabs=az-europe&pivots=standard

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
