### PR TITLE
Make documentation search platform aware

### DIFF
--- a/src/ai/ai.js
+++ b/src/ai/ai.js
@@ -44,6 +44,18 @@ function truncateText(text, maxLength) {
   return `${text.slice(0, maxLength)}...`;
 }
 
+function getKnowledgeStoreScope(area) {
+  if (area === "crime") {
+    return "Common Platform / CPP";
+  }
+
+  if (area === "other") {
+    return "Cloud Native / SDS";
+  }
+
+  return "All platforms";
+}
+
 function formatKnowledgeStoreCaptions(result) {
   if (!result.captions || result.captions.length === 0) {
     return "None";
@@ -83,21 +95,24 @@ function sanitizeResolutionSummary(resolutionSummary) {
   return truncateText(trimmed, 2900);
 }
 
-function formatKnowledgeStoreContext(knowledgeStoreResults) {
+function formatKnowledgeStoreContext(knowledgeStoreResults, area) {
+  const platformScope = getKnowledgeStoreScope(area);
+
   return knowledgeStoreResults
     .map((result, index) => {
       const document = result.document || {};
       const title = document.title || "Untitled document";
       const url = document.metadata_storage_path || "Unknown source";
       const captions = formatKnowledgeStoreCaptions(result);
-      const content = truncateText(document.content, 3500);
+      const content = truncateText(document.content, 1200);
 
       return `[${index + 1}]
+Platform: ${platformScope}
 Title: ${title}
 Source: ${url}
 Relevant search captions:
 ${captions}
-Content:
+Content excerpt:
 ${content}`;
     })
     .join("\n\n");
@@ -306,7 +321,11 @@ async function followUpQuestions(input) {
   return questions;
 }
 
-async function answerFromKnowledgeStore(question, knowledgeStoreResults) {
+async function answerFromKnowledgeStore(
+  question,
+  knowledgeStoreResults,
+  area = "other",
+) {
   if (knowledgeStoreResults.length === 0) {
     return {
       answer: "I couldn't find an answer in the documentation.",
@@ -314,7 +333,7 @@ async function answerFromKnowledgeStore(question, knowledgeStoreResults) {
     };
   }
 
-  const context = formatKnowledgeStoreContext(knowledgeStoreResults);
+  const context = formatKnowledgeStoreContext(knowledgeStoreResults, area);
 
   const result = await client.chat.completions.create({
     messages: [
@@ -324,11 +343,17 @@ async function answerFromKnowledgeStore(question, knowledgeStoreResults) {
       },
       {
         role: "user",
-        content: `Question:
+        content: `Selected platform: ${getKnowledgeStoreScope(area)}
+Question:
 ${question}
 
 Search results:
-${context}`,
+${context}
+
+Instructions:
+- Answer with the most likely fix or next step first.
+- Prefer the strongest matching result over stitching together weak matches.
+- Only use the supplied search results.`,
       },
     ],
     response_format: { type: "json_object" },

--- a/src/ai/ai.test.js
+++ b/src/ai/ai.test.js
@@ -34,6 +34,31 @@ describe("formatKnowledgeStoreCaptions", () => {
 
 describe("formatKnowledgeStoreContext", () => {
   it("puts relevant search captions into the model context", () => {
+    const context = formatKnowledgeStoreContext(
+      [
+        {
+          captions: [
+            {
+              highlights:
+                "Smoke / Functional test failure. Access the URL on VPN.",
+            },
+          ],
+          document: {
+            title: "Troubleshooting issues",
+            metadata_storage_path: "https://example.com/troubleshooting.html",
+            content: "Full document content",
+          },
+        },
+      ],
+      "other",
+    );
+
+    expect(context).toContain("Platform: Cloud Native / SDS");
+    expect(context).toContain("Relevant search captions:");
+    expect(context).toContain("Smoke / Functional test failure");
+  });
+
+  it("falls back to all platforms when the area is unknown", () => {
     const context = formatKnowledgeStoreContext([
       {
         captions: [
@@ -50,8 +75,7 @@ describe("formatKnowledgeStoreContext", () => {
       },
     ]);
 
-    expect(context).toContain("Relevant search captions:");
-    expect(context).toContain("Smoke / Functional test failure");
+    expect(context).toContain("Platform: All platforms");
   });
 });
 

--- a/src/ai/prompts.js
+++ b/src/ai/prompts.js
@@ -229,6 +229,11 @@ Rules:
 - Do not invent steps, commands, URLs, policies, owners, teams, or prerequisites.
 - Do not give generic troubleshooting advice unless it is present in the supplied search results.
 - Do not suggest raising the issue in another support channel.
+- Prefer a direct, synthesized answer that combines the strongest matching results into one clear recommendation.
+- If multiple search results describe the same fix or procedure, merge them into one answer instead of repeating each result.
+- Start with the most likely action or fix, then add the minimum supporting detail needed to act on it.
+- If the results describe a step-by-step process, format it as a short numbered list.
+- If the answer is uncertain or the results conflict, say so briefly and only state what is clearly supported.
 - Keep the answer concise and practical.
 - Use Slack mrkdwn formatting.
 - Include source references inline using the format [1], [2], etc. where the answer relies on a source.

--- a/src/service/searchKnowledgeStore.js
+++ b/src/service/searchKnowledgeStore.js
@@ -14,12 +14,16 @@ const searchClient = new SearchClient(
 );
 
 async function searchKnowledgeStore(query, area) {
-  if (area === "crime") {
-    // no known knowledge store for crime at this time so just skip it for now
-    return [];
-  }
+  const filter =
+    area === "crime"
+      ? `search.ismatch('"common-platform"', 'metadata_storage_path')`
+      : area === "other"
+        ? `search.ismatch('"cloud-native-platform"', 'metadata_storage_path')`
+        : undefined;
+
   const searchResults = await searchClient.search(query, {
     queryType: "semantic",
+    ...(filter && { filter }),
     semanticSearchOptions: {
       captions: {
         captionType: "extractive",

--- a/src/service/searchKnowledgeStore.test.js
+++ b/src/service/searchKnowledgeStore.test.js
@@ -1,0 +1,60 @@
+const mockSearch = jest.fn();
+
+jest.mock("@azure/search-documents", () => ({
+  SearchClient: jest.fn().mockImplementation(() => ({
+    search: mockSearch,
+  })),
+}));
+
+jest.mock("@azure/identity", () => ({
+  DefaultAzureCredential: jest.fn(),
+}));
+
+const { searchKnowledgeStore } = require("./searchKnowledgeStore");
+
+describe("searchKnowledgeStore", () => {
+  beforeEach(() => {
+    mockSearch.mockReset();
+  });
+
+  it("limits the docs search to cloud native platform docs for other", async () => {
+    mockSearch.mockResolvedValue({ results: [] });
+
+    await searchKnowledgeStore("github access", "other");
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      "github access",
+      expect.objectContaining({
+        filter:
+          "search.ismatch('\"cloud-native-platform\"', 'metadata_storage_path')",
+      }),
+    );
+  });
+
+  it("limits the docs search to common platform docs for crime", async () => {
+    mockSearch.mockResolvedValue({ results: [] });
+
+    await searchKnowledgeStore("github access", "crime");
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      "github access",
+      expect.objectContaining({
+        filter:
+          "search.ismatch('\"common-platform\"', 'metadata_storage_path')",
+      }),
+    );
+  });
+
+  it("searches the whole docs index when the area is not recognised", async () => {
+    mockSearch.mockResolvedValue({ results: [] });
+
+    await searchKnowledgeStore("github access", undefined);
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      "github access",
+      expect.not.objectContaining({
+        filter: expect.any(String),
+      }),
+    );
+  });
+});

--- a/src/slackHandlers/appMessaged.js
+++ b/src/slackHandlers/appMessaged.js
@@ -45,6 +45,7 @@ async function answerDirectMessage(event, client, say) {
     const knowledgeAnswer = await answerFromKnowledgeStore(
       question,
       knowledgeStoreResults,
+      "other",
     );
     const text = knowledgeAnswerText({
       answer: knowledgeAnswer.answer,


### PR DESCRIPTION

### Change description

Currently results are very confusing, it shows both platform documentations based on result. 

**Example (before change)**

It shows both common platform and cloud native platform when showing results, which doesn't make sense and probably confuses the user more. I am using the platform chosen in the first step to filter the results only from that step.

<img width="1000" height="545" alt="Screenshot 2026-07-14 at 10 00 42" src="https://github.com/user-attachments/assets/ff9aafeb-54b8-4431-8c92-4e28ace4b7fe" />

**Example (after change)**
results when we choose CNP
<img width="998" height="563" alt="Screenshot 2026-07-14 at 10 03 42" src="https://github.com/user-attachments/assets/8c5f197e-36b3-4d80-976f-abefedc67502" />

results when we choose Common platform

<img width="1032" height="269" alt="Screenshot 2026-07-14 at 10 06 12" src="https://github.com/user-attachments/assets/7afdf308-0f23-49cc-b4b5-673b530c5f0f" />

### Testing done


### Security Vulnerability Assessment ###



**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
